### PR TITLE
Correcing callback order and propagate error

### DIFF
--- a/src/main/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
+++ b/src/main/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
@@ -72,8 +72,8 @@ class SpringTestExtension(private val mode: SpringTestLifecycleMode = SpringTest
       }
       val result = execute(testCase)
       if (testCase.isApplicable()) {
-         testContextManager().afterTestMethod(testCase.spec, methodName, null as Throwable?)
-         testContextManager().afterTestExecution(testCase.spec, methodName, null as Throwable?)
+         testContextManager().afterTestExecution(testCase.spec, methodName, result.errorOrNull)
+         testContextManager().afterTestMethod(testCase.spec, methodName, result.errorOrNull)
       }
       return result
    }


### PR DESCRIPTION
Partial fix for issue kotest/kotest#4575.

Need to figure out some way to handle that Spring uses a ThreadLocal for keeping track of the TestContext to fix last problem.